### PR TITLE
update collision

### DIFF
--- a/Source/Game/VSclass/Enemy.cpp
+++ b/Source/Game/VSclass/Enemy.cpp
@@ -77,6 +77,20 @@ bool Enemy::hurt(int damage)
 	return false;
 }
 
+bool Enemy::is_collide_with(VSObject& obj, double overlap_bound)
+{
+	if (is_dead() || (!_is_enable))
+		return false;
+	return is_overlapped(*this, obj, overlap_bound);
+}
+
+bool Enemy::is_collide_with(Enemy& obj, double overlap_bound)
+{
+	if (is_dead() || (!_is_enable) || obj.is_dead() || (!obj._is_enable))
+		return false;
+	return is_overlapped(*this, obj, overlap_bound);
+}
+
 void Enemy::spawn(CPoint pos, int move_animation_delay, int death_animation_delay, int player_lvl)
 {
 	set_animation(move_animation_delay, false);

--- a/Source/Game/VSclass/Enemy.h
+++ b/Source/Game/VSclass/Enemy.h
@@ -44,6 +44,8 @@ public:
 	int get_xp_value();
 	int get_power();
 	bool hurt(int damage); //this will return true if the enemy die from this damage, otherwise false
+	bool is_collide_with(VSObject&, double overlap_bound=1);
+	bool is_collide_with(Enemy&, double overlap_bound=0.5);
 	static void load_templete_enemies();
 	static Enemy load_enemy(int id, char* name, int hp_max, int power, int mspeed, double kb, int kb_max, double res_f, bool res_k, bool res_d, double xp_value, bool hp_scale);
 	static Enemy get_templete_enemy(int id);

--- a/Source/Game/VSclass/VSObject.h
+++ b/Source/Game/VSclass/VSObject.h
@@ -48,11 +48,12 @@ public:
 	int get_direct();
 	int get_height();
 	int get_width();
-	void resolve_collide(VSObject&);
+	void append_collide(VSObject&, double overlap_bound, double factor);
+	void update_collide();
 
 	static int player_dx;
 	static int player_dy; // every time player move should update these
-	friend bool is_overlapped(VSObject&, VSObject&);
+	friend bool is_overlapped(VSObject&, VSObject&, double overlap_bound=1);
 	friend int distance(VSObject&, VSObject&);
 	friend int distance(CPoint&, CPoint&);
 	friend class QuadTree; // Friend :)
@@ -60,6 +61,7 @@ protected:
 	game_framework::CMovingBitmap _skin;
 	CPoint _position;
 	CPoint _target;
+	CPoint _collision;
 	bool _is_mirror = 0;
 	int _direct, _default_direct=LEFT;
 	int _speed=0;

--- a/Source/Game/mygame_run.cpp
+++ b/Source/Game/mygame_run.cpp
@@ -45,15 +45,16 @@ void CGameStateRun::OnInit()  								// 遊戲的初值及圖形設定
 	QT.clear();
 
 	Enemy::load_templete_enemies();
-	for (int i = 0; i < 10; i++)
-		enemy.push_back(Enemy::get_templete_enemy(GHOST));
+	for (int i = 0; i < 100; i++)
+		enemy.push_back(Enemy::get_templete_enemy(BAT2));
 
 	
+
 	for ( int i = 0; i < (int)enemy.size(); i++ ) {
-		enemy[i].spawn(CPoint(-300 + 60 * i, -400 + 80 * i));
+		enemy[i].spawn(CPoint(-300 + 30 * i/10, -400 + 40 * i%10));
 	}
 
-	Pickup::load_xp(xp_gem, 10);
+	Pickup::load_xp(xp_gem, 100);
 }
 
 void CGameStateRun::OnKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags)
@@ -119,15 +120,19 @@ void CGameStateRun::OnMove()							// 移動遊戲元素
 		vector <VSObject*> result;
 		QT.query(result, (VSObject*)(&enemy[i]));
 		for (VSObject* obj : result) {
-			enemy[i].resolve_collide(*((Enemy*)obj));
+			enemy[i].append_collide(*((Enemy*)obj), 0.75, 0.5);
 		}
-		if ((!enemy[i].is_dead()) && (enemy[i].is_enable()) && is_overlapped(enemy[i], player)) {
-			enemy[i].resolve_collide(player);
+		enemy[i].update_collide();
+		if (enemy[i].is_collide_with(player)) {
+			enemy[i].append_collide(player, 1, 0.5);
+			enemy[i].update_collide();
 			player.hurt(enemy[i].get_power());
+			/*
 			if (enemy[i].hurt(1)) {
 				//when the enemy die from this damage
 				xp_gem[i].spawn_xp(enemy[i].get_pos(), enemy[i].get_xp_value());
 			}
+			*/
 		}
 	}
 	QT.clear();


### PR DESCRIPTION
Things i did:
- overlap detection
change overlap detection to allow a factor, which is how big the percentage to consider objects are "overlapping"

 - collision
change / clean up the way to deal with collision, its now need 2 variables, overlap_bound, smooth_factor.
And split it into 2 functions, ```append_collision``` and ```update_collision```.
Here is how it works:
1. when obj overlap with other obj, call the append_collision. It will ...
2. compute the dx, dy (the change it need to add to be at the edge of the overlap boundary and times smooth_factor)
3. then, store them into the new class variable _collision
4. after series of append_collision, call update_collison. It will update this obj's position and reset _collision

- add ```Enemy::is_collide_with()```