### PR TITLE
Object pool

### DIFF
--- a/Source/Game/VSclass/Enemy.cpp
+++ b/Source/Game/VSclass/Enemy.cpp
@@ -45,6 +45,9 @@ int Enemy::get_power()
 {
 	return _power;
 }
+int Enemy::get_id() {
+	return _id;
+}
 
 void Enemy::show_skin(double factor)
 {

--- a/Source/Game/VSclass/Enemy.h
+++ b/Source/Game/VSclass/Enemy.h
@@ -42,6 +42,7 @@ public:
 	void update_pos(CPoint) override;
 	bool is_dead();
 	bool is_enable();
+	int get_id();
 	int get_xp_value();
 	int get_power();
 	bool hurt(int damage); //this will return true if the enemy die from this damage, otherwise false

--- a/Source/Game/VSclass/ObjPool.h
+++ b/Source/Game/VSclass/ObjPool.h
@@ -1,25 +1,92 @@
-#pragma once
+﻿#pragma once
+//#pragma once
+//template <class T>
+//class ObjPool
+//{
+//public:
+//    ObjPool() {}
+//    ObjPool(int type) : pool_type(type) {}
+//    ~ObjPool() {}
+//
+//    void add_obj(int id, int count)
+//    {
+//        auto& obj_list = pool[id];
+//        obj_list.reserve(obj_list.size() + count);
+//        for (int i = 0; i < count; i++)
+//        {
+//            obj_list.emplace_back(id);
+//        }
+//    }
+//
+//    T& get_obj(int id)
+//    {
+//        auto& obj_list = pool[id];
+//        if (obj_list.empty())
+//        {
+//            add_obj(id, 1);
+//        }
+//        T& obj = obj_list.back();
+//        obj_list.pop_back();
+//        return obj;
+//    }
+//
+//    std::vector<std::reference_wrapper<T>> get_obj(int id, int count)
+//    {
+//        auto& obj_list = pool[id];
+//        std::vector<std::reference_wrapper<T>> result;
+//        result.reserve(count);
+//        for (int i = 0; i < count; i++)
+//        {
+//            if (obj_list.empty())
+//            {
+//                add_obj(id, count - i);
+//            }
+//            result.emplace_back(obj_list.back());
+//            obj_list.pop_back();
+//        }
+//        return result;
+//    }
+//
+//    void free_obj(T& obj)
+//    {
+//        int id = obj.get_id();
+//        auto& obj_list = pool[id];
+//        obj_list.emplace_back(std::move(obj));
+//    }
+//
+//    int pool_type = 0;
+//
+//private:
+//    std::map<int, std::vector<T>> pool;
+//};
+
 template <class T>
 class ObjPool
 {
 public:
 	ObjPool() {}
-	ObjPool(int) {
+	ObjPool(int type) {
 		pool_type = type;
 	}
 	~ObjPool(){}
-	void add_obj(int id, int count) {
+	void add_obj(int id, int count) { // this should be only execute once 
+		int start_index = pool[id].size();
 		for (int i = 0; i < count; i++) {
 			pool[id].push_back(T(id));
+			🔞[id].push_back(i + start_index);
 		}
 	}
 
 	T& get_obj(int id) {
 		if (pool[id].size() == 0) {
-			add_obj(id, 1);
+			VS_ASSERT(false, "The pool is empty, please add more object to the pool");
 		}
-		T& obj = pool[id].back();
-		pool[id].pop_back();
+		if (🔞[id].size() < 0) {
+			VS_ASSERT(false, "exceed poo limit");
+		}
+		T& obj = pool[id][🔞[id].back()];
+		obj.set_pool_id(id);
+		🔞[id].pop_back();
 		return obj;
 	}
 	vector<reference_wrapper<T>> get_obj(int id, int count) {
@@ -29,10 +96,12 @@ public:
 		}
 		return obj_list;
 	}
-	void free_obj(T&) {
-		pool[T.get_id()].push_back(obj);
+	void free_obj(T& obj) {
+		int id = obj.get_pool_id();
+		🔞[obj.get_id()].push_back(id);
 	}
 	int pool_type;
 private:
 	map<int, vector<T>> pool;
+	map<int, vector<int>> 🔞;
 };

--- a/Source/Game/VSclass/ObjPool.h
+++ b/Source/Game/VSclass/ObjPool.h
@@ -81,8 +81,8 @@ public:
 		if (pool[id].size() == 0) {
 			VS_ASSERT(false, "The pool is empty, please add more object to the pool");
 		}
-		if (🔞[id].size() < 0) {
-			VS_ASSERT(false, "exceed poo limit");
+		if (🔞[id].size() <= 0) { // keep first for reseting
+			VS_ASSERT(false, "exceeded pool limit");
 		}
 		T& obj = pool[id][🔞[id].back()];
 		obj.set_pool_id(id);
@@ -97,8 +97,9 @@ public:
 		return obj_list;
 	}
 	void free_obj(T& obj) {
-		int id = obj.get_pool_id();
-		🔞[obj.get_id()].push_back(id);
+		int id = obj.get_pool_id(), obj_id = obj.get_id();
+		🔞[obj_id].push_back(id);
+		pool[obj_id][id] = pool[obj_id][0];
 	}
 	int pool_type;
 private:

--- a/Source/Game/VSclass/ObjPool.h
+++ b/Source/Game/VSclass/ObjPool.h
@@ -69,7 +69,7 @@ public:
 		pool_type = type;
 	}
 	~ObjPool(){}
-	void add_obj(int id, int count) { // this should be only execute once 
+	void add_obj(int id, int count) { // this should be only execute once or not?
 		int start_index = pool[id].size();
 		for (int i = 0; i < count; i++) {
 			pool[id].push_back(T(id));
@@ -78,14 +78,12 @@ public:
 	}
 
 	T& get_obj(int id) {
-		if (pool[id].size() == 0) {
-			VS_ASSERT(false, "The pool is empty, please add more object to the pool");
-		}
-		if (🔞[id].size() <= 0) { // keep first for reseting
-			VS_ASSERT(false, "exceeded pool limit");
-		}
+		VS_ASSERT(pool[id].size() > 0, "The pool is empty, please add more object to the pool");
+		// keep first for reseting
+		VS_ASSERT(🔞[id].size() > 0, "exceeded pool limit");
+		
 		T& obj = pool[id][🔞[id].back()];
-		obj.set_pool_id(id);
+		obj.set_pool_id(🔞[id].back());
 		🔞[id].pop_back();
 		return obj;
 	}

--- a/Source/Game/VSclass/ObjPool.h
+++ b/Source/Game/VSclass/ObjPool.h
@@ -8,31 +8,31 @@ public:
 		pool_type = type;
 	}
 	~ObjPool(){}
-	void add_obj(int type, int count) {
+	void add_obj(int id, int count) {
 		for (int i = 0; i < count; i++) {
-			pool.push_back(T(type));
+			pool[id].push_back(T(id));
 		}
 	}
 
-	T& get_obj(int type) {
-		if (pool.size() == 0) {
-			add_obj(type, 1);
+	T& get_obj(int id) {
+		if (pool[id].size() == 0) {
+			add_obj(id, 1);
 		}
-		T& obj = pool.back();
-		pool.pop_back();
+		T& obj = pool[id].back();
+		pool[id].pop_back();
 		return obj;
 	}
-	vector<reference_wrapper<T>> get_obj(int type, int count) {
+	vector<reference_wrapper<T>> get_obj(int id, int count) {
 		vector<reference_wrapper<T>> obj_list;
 		for (int i = 0; i < count; i++) {
-			obj_list.push_back(get_obj(type));
+			obj_list.push_back(get_obj(id));
 		}
 		return obj_list;
 	}
 	void free_obj(T&) {
-		pool.push_back(obj);
+		pool[T.get_id()].push_back(obj);
 	}
 	int pool_type;
 private:
-	vector<T> pool;
+	map<int, vector<T>> pool;
 };

--- a/Source/Game/VSclass/ObjPool.h
+++ b/Source/Game/VSclass/ObjPool.h
@@ -73,6 +73,7 @@ public:
 		int start_index = pool[id].size();
 		for (int i = 0; i < count; i++) {
 			pool[id].push_back(T(id));
+			pool[id].back().set_pool_id(i + start_index);
 			🔞[id].push_back(i + start_index);
 		}
 	}
@@ -83,7 +84,7 @@ public:
 		VS_ASSERT(🔞[id].size() > 0, "exceeded pool limit");
 		
 		T& obj = pool[id][🔞[id].back()];
-		obj.set_pool_id(🔞[id].back());
+		// obj.set_pool_id(🔞[id].back());
 		🔞[id].pop_back();
 		return obj;
 	}
@@ -98,6 +99,7 @@ public:
 		int id = obj.get_pool_id(), obj_id = obj.get_id();
 		🔞[obj_id].push_back(id);
 		pool[obj_id][id] = pool[obj_id][0];
+		pool[obj_id][id].set_pool_id(id);
 	}
 	int pool_type;
 private:

--- a/Source/Game/VSclass/Projectile.cpp
+++ b/Source/Game/VSclass/Projectile.cpp
@@ -215,6 +215,9 @@ void Projectile::set_rotation(double radien) {
 	this->_skin.ResetBitmap();
 	this->_skin.LoadBitmapByString(rotated_filename, RGB(1,11,111));
 }
+int Projectile::get_id() {
+	return _type;
+}
 deque<Projectile> Projectile::all_proj = {};
 ObjPool<Projectile> Projectile::pool;
 deque<reference_wrapper<Projectile>> Projectile::all_proj_ref = {};

--- a/Source/Game/VSclass/Projectile.cpp
+++ b/Source/Game/VSclass/Projectile.cpp
@@ -125,14 +125,16 @@ void Projectile::show() {
 			rf.show_skin();
 			rf._is_start = true;
 		}
-		if (rf._is_over) {
-			pool.free_obj(rf);
+	}
+	for (auto it = all_proj.begin(); it != all_proj.end();) {
+		if (it->get()._is_over) {
+			pool.free_obj(it->get());
+			it = all_proj.erase(it);
+		}
+		else {
+			++it;
 		}
 	}
-	auto iter = remove_if(all_proj.begin(), all_proj.end(), [](reference_wrapper<Projectile>& a) {
-		return a.get()._is_over;
-	});
-	all_proj.erase(iter, all_proj.end());
 	if (clock() % 60000 == 0) {
 		all_proj.shrink_to_fit(); // release memory
 	}

--- a/Source/Game/VSclass/Projectile.cpp
+++ b/Source/Game/VSclass/Projectile.cpp
@@ -108,7 +108,7 @@ void Projectile::show_skin(double factor) {
 		this->_is_over = true;
 }
 void Projectile::show() {
-	int deq_size = static_cast<int> (all_proj.size());
+	// int deq_size = static_cast<int> (all_proj.size());
 	/*for (int i = 0; i < deq_size; i++) {
 		if (clock() - all_proj.front()._create_time >= all_proj.front()._delay) {
 			all_proj.front().show_skin();

--- a/Source/Game/VSclass/Projectile.h
+++ b/Source/Game/VSclass/Projectile.h
@@ -29,9 +29,10 @@ public:
 	static void create_projectile(Projectile p);
 	static void update_position();
 	static void show();
-	static deque<Projectile> all_proj;
-	static deque<reference_wrapper<Projectile>> all_proj_ref;
+	// static deque<Projectile> all_proj;
+	static vector<reference_wrapper<Projectile>> all_proj;
 	static ObjPool<Projectile> pool;
+	static std::map<int, Projectile> template_proj;
 protected:
 	int _type, _level, _max_level, _rarity,
 		_amount, _duration, _pierce, _proj_interval,
@@ -40,7 +41,6 @@ protected:
 	int _delay;
 	std::vector<std::string> _file_name;
 	std::map<int, game_framework::CMovingBitmap> _rotation_skin;
-	std::map<int, Projectile> template_proj;
 	// int _speed; hide it then VSObject could see it
 	double _area, _damage, _knock_back, _angle;
 	bool _is_over = 0, _is_start = 0;

--- a/Source/Game/VSclass/Projectile.h
+++ b/Source/Game/VSclass/Projectile.h
@@ -22,6 +22,7 @@ public:
 	void HOLY_MISSILE_transition();
 	void collide_with_enemy(Enemy&);
 	void set_rotation(double);
+	int get_id();
 	// int _type, _level, _max_level, _damage, _speed, _rarity,  _amount, _duration, _pierce, _cooldown, _proj_interval, _hitbox_delay, _knock_back, _pool_limit, _chance, _crit_multi, _block_by_wall;
 	static void create_projectile(Projectile proj, CPoint position, CPoint target_pos, int delay, int type, double damage,int speed, int duration, int pierce, int proj_interval, int hitbox_delay, double knock_back, int pool_limit, int chance, int criti_multi, int block_by_wall, bool is_mirror);
 	static void create_projectile(CPoint position, CPoint target_pos, int delay, int type, double damage, int speed, int duration, int pierce, int proj_interval, int hitbox_delay, double knock_back, int pool_limit, int chance, int criti_multi, int block_by_wall, bool is_mirror);

--- a/Source/Game/VSclass/Projectile.h
+++ b/Source/Game/VSclass/Projectile.h
@@ -14,7 +14,6 @@ public:
 	void show_skin(double factor = 1.0) override;
 	void set_offset(CPoint);
 	void set_life_cycle(clock_t);
-	void init_projectile(int type, int count);
 	void WHIP_transition();
 	void VAMPIRICA_transition();
 	void MAGIC_MISSILE_transition();
@@ -24,8 +23,8 @@ public:
 	void set_rotation(double);
 	int get_id();
 	// int _type, _level, _max_level, _damage, _speed, _rarity,  _amount, _duration, _pierce, _cooldown, _proj_interval, _hitbox_delay, _knock_back, _pool_limit, _chance, _crit_multi, _block_by_wall;
-	static void create_projectile(Projectile proj, CPoint position, CPoint target_pos, int delay, int type, double damage,int speed, int duration, int pierce, int proj_interval, int hitbox_delay, double knock_back, int pool_limit, int chance, int criti_multi, int block_by_wall, bool is_mirror);
-	static void create_projectile(CPoint position, CPoint target_pos, int delay, int type, double damage, int speed, int duration, int pierce, int proj_interval, int hitbox_delay, double knock_back, int pool_limit, int chance, int criti_multi, int block_by_wall, bool is_mirror);
+	static void init_projectile(int type, int count);
+	static void create_projectile(Projectile& proj, CPoint position, CPoint target_pos, int delay, int type, double damage,int speed, int duration, int pierce, int proj_interval, int hitbox_delay, double knock_back, int pool_limit, int chance, int criti_multi, int block_by_wall, bool is_mirror);
 	static void create_projectile(Projectile p);
 	static void update_position();
 	static void show();

--- a/Source/Game/VSclass/VSObject.cpp
+++ b/Source/Game/VSclass/VSObject.cpp
@@ -110,6 +110,12 @@ int VSObject::distance(CPoint& p1, CPoint& p2)
 {
 	return fast_sqrt(square(p1.x - p2.x) + square(p1.y - p2.y));
 }
+void VSObject::set_pool_id(int id) {
+	_pool_id = id;
+}
+int VSObject::get_pool_id() {
+	return _pool_id;
+}
 void VSObject::update_pos()
 {
 	// have a speed and moving in a 2d plane

--- a/Source/Game/VSclass/VSObject.h
+++ b/Source/Game/VSclass/VSObject.h
@@ -46,7 +46,6 @@ public:
 	static int distance(CPoint&, CPoint&);
 	friend class QuadTree; 
 	int obj_type = VSOBJECT;
-	int id;
 protected:
 	game_framework::CMovingBitmap _skin;
 	vector <game_framework::CMovingBitmap> _animations;

--- a/Source/Game/VSclass/VSObject.h
+++ b/Source/Game/VSclass/VSObject.h
@@ -22,6 +22,8 @@ public:
 	void set_pos(double, double);
 	void set_target_vec(CPoint);
 	void set_target_vec(int, int);
+	void set_pool_id(int);
+	int get_pool_id();
 	virtual void set_speed(int);
 	virtual void set_speed(double);
 	void select_show_animation(int);
@@ -56,6 +58,7 @@ protected:
 	bool _is_mirror = 0;
 	int _direct, _default_direct=LEFT;
 	int _speed=0;
+	int _pool_id;
 	double _fx, _fy;
 };
 

--- a/Source/Game/VSclass/Weapon.cpp
+++ b/Source/Game/VSclass/Weapon.cpp
@@ -388,24 +388,29 @@ void Weapon::load_weapon_stats() {
 			p.set_animation(300, true, 0);
 			p.set_life_cycle(300);
 			p.enable_animation();
+			Projectile::pool.add_obj(type, 10);
 			break;
 		case MAGIC_MISSILE:
 			p.set_default_direct(RIGHT);
 			p.set_life_cycle(-1);
+			Projectile::pool.add_obj(type, w._pool_limit);
 			break;
 		case KNIFE:
 			p.set_default_direct(RIGHT);
 			p.set_life_cycle(-1);
+			Projectile::pool.add_obj(type, w._pool_limit);
 			break;
 		case VAMPIRICA:
 			p.set_default_direct(RIGHT);
 			p.set_animation(300, true, 0);
 			p.set_life_cycle(300);
 			p.enable_animation();
+			Projectile::pool.add_obj(type, 10);
 			break; 
 		case HOLY_MISSILE:
 			p.set_default_direct(RIGHT);
 			p.set_life_cycle(-1);
+			Projectile::pool.add_obj(type, w._pool_limit);
 			break;
 		}
 		w._base_proj = p;

--- a/Source/Game/VSclass/Weapon.cpp
+++ b/Source/Game/VSclass/Weapon.cpp
@@ -118,10 +118,11 @@ void Weapon::attack() {
 			continue;
 		}
 		w._last_time_attack = clock();
+
 		switch (w._type) {
 		case (WHIP):
 			for (int i = 0; i < w._amount; i++) {
-				Projectile proj = w._base_proj;
+				Projectile& proj = Projectile::pool.get_obj(WHIP);
 				proj.set_create_time(clock());
 				if (mouse_pos.x > player_pos.x) {
 					if (!(i & 1)) {
@@ -152,7 +153,7 @@ void Weapon::attack() {
 
 		case MAGIC_MISSILE:
 			for (int i = 0; i < w._amount; i++) {
-				Projectile proj = w._base_proj;
+				Projectile& proj = Projectile::pool.get_obj(MAGIC_MISSILE);
 				proj.set_pos(player_pos);
 				proj.set_create_time(clock());
 				CPoint target = player_pos;
@@ -167,7 +168,7 @@ void Weapon::attack() {
 			break;
 		case KNIFE:
 			for (int i = 0; i < w._amount; i++) {
-				Projectile proj = w._base_proj;
+				Projectile& proj = Projectile::pool.get_obj(WHIP);
 				proj.set_create_time(clock());
 				proj.set_target_vec(mouse_pos - player_pos);
 				double rotate = atan2(mouse_pos.y - player_pos.y, mouse_pos.x - player_pos.x);
@@ -182,7 +183,7 @@ void Weapon::attack() {
 			break;
 		case (VAMPIRICA):
 			for (int i = 0; i < w._amount; i++) {
-				Projectile proj = w._base_proj;
+				Projectile& proj = Projectile::pool.get_obj(VAMPIRICA);
 				proj.set_create_time(clock());
 				if (mouse_pos.x > player_pos.x) {
 					if (!(i & 1)) {
@@ -211,16 +212,16 @@ void Weapon::attack() {
 			}
 			break;
 		case HOLY_MISSILE:
-			Projectile proj = w._base_proj;
-			proj.set_pos(player_pos);
-			proj.set_create_time(clock());
-			CPoint target = player_pos;
-			int min_dis = 1000000000;
-			QuadTree::VSPlain.query_nearest_enemy_pos(target, (VSObject*)(&proj), min_dis);
-			proj.set_target_vec((target != player_pos ? target - player_pos : (mouse_pos.x > player_pos.x ? (100,10) : (-100,10))));
-			double rad = atan2(target.y - player_pos.y, target.x - player_pos.x);
-			proj.set_rotation(rad);
 			for (int i = 0; i < w._amount; i++) {
+				Projectile& proj = Projectile::pool.get_obj(HOLY_MISSILE);
+				proj.set_pos(player_pos);
+				proj.set_create_time(clock());
+				CPoint target = player_pos;
+				int min_dis = 1000000000;
+				QuadTree::VSPlain.query_nearest_enemy_pos(target, (VSObject*)(&proj), min_dis);
+				proj.set_target_vec((target != player_pos ? target - player_pos : (mouse_pos.x > player_pos.x ? (100,10) : (-100,10))));
+				double rad = atan2(target.y - player_pos.y, target.x - player_pos.x);
+				proj.set_rotation(rad);
 				Projectile::create_projectile(proj, player_pos, (target), w._type, i * w._proj_interval, w._damage, w._speed, w._duration, w._pierce, w._proj_interval, w._hitbox_delay,
 					w._knock_back, w._pool_limit, w._chance, w._crit_multi, w._block_by_wall, false);
 			}
@@ -388,32 +389,29 @@ void Weapon::load_weapon_stats() {
 			p.set_animation(300, true, 0);
 			p.set_life_cycle(300);
 			p.enable_animation();
-			Projectile::pool.add_obj(type, 10);
 			break;
 		case MAGIC_MISSILE:
 			p.set_default_direct(RIGHT);
 			p.set_life_cycle(-1);
-			Projectile::pool.add_obj(type, w._pool_limit);
 			break;
 		case KNIFE:
 			p.set_default_direct(RIGHT);
 			p.set_life_cycle(-1);
-			Projectile::pool.add_obj(type, w._pool_limit);
 			break;
 		case VAMPIRICA:
 			p.set_default_direct(RIGHT);
 			p.set_animation(300, true, 0);
 			p.set_life_cycle(300);
 			p.enable_animation();
-			Projectile::pool.add_obj(type, 10);
 			break; 
 		case HOLY_MISSILE:
 			p.set_default_direct(RIGHT);
 			p.set_life_cycle(-1);
-			Projectile::pool.add_obj(type, w._pool_limit);
 			break;
 		}
 		w._base_proj = p;
+		Projectile::template_proj[type] = p;
+		Projectile::pool.add_obj(type, w._pool_limit);
 		Weapon::_base_weapon[ type ] = w;
 	}
 }


### PR DESCRIPTION
## Why PR
+ I think we should use `shred_ptr` for Object pool
+ But the `reference_wrapper` version is stable now for projectile
+ If we decide use pointer version Object pool, keep this pr on hold till the modify over
+ If we decide to use this version, it is important not to use the code below to erase while iterating.
```cpp
auto itor = std::remove_if(all_obj.begin(), all_obj.end(), [](const obj& object){return !object.is_over();});
all_obj.erase(itor, all_obj.end());
```
+ It should be like this
```cpp
for (auto it = all_obj.begin(); it != obj.end();) {
	if (it->get().is_over()) {
		pool.free_obj(it->get());
		it = all_proj.erase(it);
	}
	else {
		++it;
	}
}
```
